### PR TITLE
Add support for appName in LocalSyslog

### DIFF
--- a/src/Serilog.Sinks.Syslog/Sinks/LocalSyslogService.cs
+++ b/src/Serilog.Sinks.Syslog/Sinks/LocalSyslogService.cs
@@ -44,12 +44,14 @@ namespace Serilog.Sinks.Syslog
         [DllImport("libc")]
         private static extern void closelog();
 
-        private IntPtr appIdentityHandle = IntPtr.Zero;
         private readonly Facility facility;
+        private readonly string appIdentity;
+        private IntPtr appIdentityHandle = IntPtr.Zero;
 
-        public LocalSyslogService(Facility facility)
+        public LocalSyslogService(Facility facility, string appIdentity = null)
         {
             this.facility = facility;
+            this.appIdentity = appIdentity ?? AppDomain.CurrentDomain.FriendlyName;
         }
 
         /// <summary>
@@ -57,8 +59,7 @@ namespace Serilog.Sinks.Syslog
         /// </summary>
         public virtual void Open()
         {
-            var appIdentity = AppDomain.CurrentDomain.FriendlyName;
-            this.appIdentityHandle = Marshal.StringToHGlobalAnsi(appIdentity);
+            this.appIdentityHandle = Marshal.StringToHGlobalAnsi(this.appIdentity ?? AppDomain.CurrentDomain.FriendlyName);
 
             openlog(this.appIdentityHandle, SyslogOptions.LOG_PID, this.facility);
         }

--- a/src/Serilog.Sinks.Syslog/SyslogLoggerConfigurationExtensions.cs
+++ b/src/Serilog.Sinks.Syslog/SyslogLoggerConfigurationExtensions.cs
@@ -27,20 +27,21 @@ namespace Serilog
         /// Adds a sink that writes log events to the local syslog service on a Linux system
         /// </summary>
         /// <param name="loggerSinkConfig">The logger configuration</param>
+        /// <param name="appName">The name of the application. Defaults to the current process name</param>
         /// <param name="facility">The category of the application</param>
         /// <param name="outputTemplate">A message template describing the output messages
         /// <param name="restrictedToMinimumLevel">The minimum level for events passed through the sink</param>
         /// <seealso cref="https://github.com/serilog/serilog/wiki/Formatting-Output"/>
         /// </param>
         public static LoggerConfiguration LocalSyslog(this LoggerSinkConfiguration loggerSinkConfig,
-            Facility facility = Facility.Local0, string outputTemplate = null,
+            string appName = null, Facility facility = Facility.Local0, string outputTemplate = null,
             LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum)
         {
             if (!RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
                 throw new ArgumentException("The local syslog sink is only supported on Linux systems");
 
-            var formatter = GetFormatter(SyslogFormat.Local, null, facility, outputTemplate);
-            var syslogService = new LocalSyslogService(facility);
+            var formatter = GetFormatter(SyslogFormat.Local, appName, facility, outputTemplate);
+            var syslogService = new LocalSyslogService(facility, appName);
             syslogService.Open();
 
             var sink = new SyslogLocalSink(formatter, syslogService);


### PR DESCRIPTION
Simple way of adding support for the appName Configuration in LocalSyslog. Issue: #3 