### PR TITLE
Checking if client socket is not null.  

### DIFF
--- a/src/Serilog.Sinks.Syslog/Sinks/SyslogTcpSink.cs
+++ b/src/Serilog.Sinks.Syslog/Sinks/SyslogTcpSink.cs
@@ -1,5 +1,5 @@
 // Copyright 2018 Ionx Solutions (https://www.ionxsolutions.com)
-// Ionx Solutions licenses this file to you under the Apache License, 
+// Ionx Solutions licenses this file to you under the Apache License,
 // Version 2.0. You may obtain a copy of the License at
 // http://www.apache.org/licenses/LICENSE-2.0
 
@@ -158,7 +158,7 @@ namespace Serilog.Sinks.Syslog
 
         private bool IsConnected()
         {
-            if (this.client == null || !this.client.Connected)
+            if (this.client?.Client == null || !this.client.Connected)
                 return false;
 
             var socket = this.client.Client;


### PR DESCRIPTION
When running in .NET 4.x if the TCP endpoint is not reachable then the retry loop will stop.  

For NET 4.0 `IsConnected` is implemented as below

```
public bool Connected
{
  get
  {
    return this.m_ClientSocket.Connected;
  }
}
```

This is why the check for the client is required.