### PR TITLE
Dispose base first 

### DIFF
--- a/src/Serilog.Sinks.Syslog/Sinks/SyslogTcpSink.cs
+++ b/src/Serilog.Sinks.Syslog/Sinks/SyslogTcpSink.cs
@@ -212,6 +212,7 @@ namespace Serilog.Sinks.Syslog
 
         protected override void Dispose(bool disposing)
         {
+            base.Dispose(disposing);
             if (!this.disposed)
             {
                 // If disposing == true, we're being called from an inheriting class calling base.Dispose()
@@ -225,8 +226,6 @@ namespace Serilog.Sinks.Syslog
 
                 this.disposed = true;
             }
-
-            base.Dispose(disposing);
         }
     }
 }

--- a/src/Serilog.Sinks.Syslog/Sinks/SyslogUdpSink.cs
+++ b/src/Serilog.Sinks.Syslog/Sinks/SyslogUdpSink.cs
@@ -56,6 +56,7 @@ namespace Serilog.Sinks.Syslog
 
         protected override void Dispose(bool disposing)
         {
+            base.Dispose(disposing);
             if (!this.disposed)
             {
                 // If disposing == true, we're being called from an inheriting class calling base.Dispose()
@@ -68,8 +69,6 @@ namespace Serilog.Sinks.Syslog
 
                 this.disposed = true;
             }
-
-            base.Dispose(disposing);
         }
     }
 }


### PR DESCRIPTION
Dispose base class first so that any outstanding events are processed before disposing the client.
I ran into a bug when using this sink in a console application. Log.CloseAndFlush has to be called before exiting the application, this starts a Dispose chain which leads to a NullReferenceException because SyslogUdpSink sets it's client to null and the PeriodicBatchingSink calls the OnTick/EmitBatchAsync one last time.