### PR TITLE
Expose SslStream.AuthenticateAsClient's CheckCertificateRevocation Parameter

### DIFF
--- a/src/Serilog.Sinks.Syslog/Sinks/Settings/SyslogTcpConfig.cs
+++ b/src/Serilog.Sinks.Syslog/Sinks/Settings/SyslogTcpConfig.cs
@@ -61,5 +61,14 @@ namespace Serilog.Sinks.Syslog
         /// Callback to validate the server's SSL certificate. If null, the system default will be used
         /// </summary>
         public RemoteCertificateValidationCallback CertValidationCallback { get; set; }
+        
+        /// <summary>
+        /// When making a secure TCP connection, determines whether the server's certificate CRL, if
+        /// specified in the CRL Distribution Point (CDP) extension of the certificate or any intermediate
+        /// certificates, will be downloaded and checked for revocation. If any certificate within the
+        /// certificate chain has been revoked, the connection will be aborted. That behavior, of course,
+        /// can be customized by using the <see cref="CertValidationCallback"/> handler.
+        /// </summary>
+        public bool CheckCertificateRevocation { get; set; } = false;
     }
 }

--- a/src/Serilog.Sinks.Syslog/Sinks/SyslogTcpSink.cs
+++ b/src/Serilog.Sinks.Syslog/Sinks/SyslogTcpSink.cs
@@ -35,6 +35,7 @@ namespace Serilog.Sinks.Syslog
         private readonly SslProtocols secureProtocols;
         private readonly X509Certificate2Collection clientCert;
         private readonly RemoteCertificateValidationCallback certValidationCallback;
+        private readonly bool checkCertificateRevocation;
 
         public string Host { get; }
         public int Port { get; }
@@ -50,6 +51,7 @@ namespace Serilog.Sinks.Syslog
             this.secureProtocols = config.SecureProtocols;
             this.useTls = config.SecureProtocols != SslProtocols.None;
             this.certValidationCallback = config.CertValidationCallback;
+            this.checkCertificateRevocation = config.CheckCertificateRevocation;
 
             if (config.CertProvider?.Certificate != null)
             {
@@ -148,7 +150,7 @@ namespace Serilog.Sinks.Syslog
             // Note: this method takes an X509CertificateCollection, rather than an X509Certificate,
             // but providing the full chain does not actually appear to work for many servers
             await sslStream.AuthenticateAsClientAsync(this.Host, this.clientCert,
-                this.secureProtocols, false).ConfigureAwait(false);
+                this.secureProtocols, this.checkCertificateRevocation).ConfigureAwait(false);
 
             if (!sslStream.IsAuthenticated)
                 throw new AuthenticationException("Unable to authenticate secure syslog server");


### PR DESCRIPTION
See Issue #14 for more details. Add an additional property to the `SyslogTcpConfig` class named `CheckCertificateRevocation`. That property value is then used in the `SslStream.AuthenticateAsClientAsync()` when the connection is made. This allows the caller to decide if they want CRL checking or not, instead of it always being hard coded to `false`. The default remains `false`, however, to preserve backwards compatibility.