### PR TITLE
Support TCP IPv6

### DIFF
--- a/src/Serilog.Sinks.Syslog/Sinks/SyslogTcpSink.cs
+++ b/src/Serilog.Sinks.Syslog/Sinks/SyslogTcpSink.cs
@@ -110,7 +110,11 @@ namespace Serilog.Sinks.Syslog
                 // Recreate the TCP client
                 this.stream?.Dispose();
                 this.client?.Close();
-                this.client = new TcpClient();
+
+                // Allow connections to be made via IPv4 or IPv6. With just the default constructor,
+                // only IPv4 can be used.
+                this.client = new TcpClient(AddressFamily.InterNetworkV6);
+                this.client.Client.DualMode = true;
 
                 // If we're running on Linux, only try to set keep-alives if they are wanted (in
                 // that case we resolved the hostname to an IP in the ctor)

--- a/test/Serilog.Sinks.Syslog.Tests/TcpSyslogSinkTests.cs
+++ b/test/Serilog.Sinks.Syslog.Tests/TcpSyslogSinkTests.cs
@@ -43,16 +43,9 @@ namespace Serilog.Sinks.Syslog.Tests
             await SendUnsecureAsync(IPAddress.Loopback);
         }
 
-        [Fact]
+        [Fact(Skip = "IPV6 is not yet available in the Travis or AppVeyor CI environments")]
         public async Task Should_send_logs_to_ipv6_tcp_syslog_service()
         {
-            var nics = NetworkInterface.GetAllNetworkInterfaces();
-
-            if (!nics.Any(x => x.Supports(NetworkInterfaceComponent.IPv6)))
-            {
-                return;
-            }
-
             await SendUnsecureAsync(IPAddress.IPv6Loopback);
         }
 

--- a/test/Serilog.Sinks.Syslog.Tests/TcpSyslogSinkTests.cs
+++ b/test/Serilog.Sinks.Syslog.Tests/TcpSyslogSinkTests.cs
@@ -6,7 +6,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
-using System.Net.Sockets;
+using System.Net.NetworkInformation;
 using System.Security.Authentication;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading;
@@ -46,6 +46,13 @@ namespace Serilog.Sinks.Syslog.Tests
         [Fact]
         public async Task Should_send_logs_to_ipv6_tcp_syslog_service()
         {
+            var nics = NetworkInterface.GetAllNetworkInterfaces();
+
+            if (!nics.Any(x => x.Supports(NetworkInterfaceComponent.IPv6)))
+            {
+                return;
+            }
+
             await SendUnsecureAsync(IPAddress.IPv6Loopback);
         }
 


### PR DESCRIPTION
See Issue #13.

When the Syslog sink is configured for TCP, and an IPv6 address was specified for the host server, no connection would be made and no messages would be sent. By default, the `TcpClient` constructor will only operate with IPv4. Therefore, we must explicitly specify `IPv6Any` and set the `DualMode` property to `true` in order to support either IPv4 or IPv6. We then don't have to worry about anything else, like whether the machine even has IPv6 enabled.

Modified the Unit Test `TcpListener` to also support IPv6 and use a random, system chosen port at start instead of creating an additional `Socket` object.

Here is a screen shot of the Unit Tests from Visual Studio 2019 on Windows:
![image](https://user-images.githubusercontent.com/22459191/106405534-bfbd7780-63f3-11eb-8594-7b4480022ee8.png)

And here is a screen shot of the Unit Tests fro VSCode running on Ubuntu 20.04:
![image](https://user-images.githubusercontent.com/22459191/106405545-c9df7600-63f3-11eb-9ee2-6f52882fade1.png)
