### PR TITLE
Implement Timeout for AuthenticateAsClientAsync

### DIFF
--- a/src/Serilog.Sinks.Syslog/Sinks/Settings/SyslogTcpConfig.cs
+++ b/src/Serilog.Sinks.Syslog/Sinks/Settings/SyslogTcpConfig.cs
@@ -3,6 +3,7 @@
 // Version 2.0. You may obtain a copy of the License at
 // http://www.apache.org/licenses/LICENSE-2.0
 
+using System;
 using System.Net.Security;
 using System.Security.Authentication;
 
@@ -70,5 +71,16 @@ namespace Serilog.Sinks.Syslog
         /// can be customized by using the <see cref="CertValidationCallback"/> handler.
         /// </summary>
         public bool CheckCertificateRevocation { get; set; } = false;
+
+        /// <summary>
+        /// A timeout value for the TCP connection to perform the TLS handshake with the server. This is
+        /// only applicable if <see cref="SecureProtocols"/> is set to a value other than the default,
+        /// <see cref="SslProtocols.None"/>. This timeout value will ensure that if the server happens
+        /// to not support TLS at all, for example, the connection may appear to hang, waiting for it to
+        /// complete. This timeout will cause a disconnect and raise an exception after the elapsed time.
+        /// The default value is 100 seconds.
+        /// </summary>
+        /// <remarks>This does not control the initial TCP connection timeout.</remarks>
+        public TimeSpan TlsAuthenticationTimeout { get; set; } = TimeSpan.FromSeconds(100);
     }
 }

--- a/src/Serilog.Sinks.Syslog/Sinks/SyslogTcpSink.cs
+++ b/src/Serilog.Sinks.Syslog/Sinks/SyslogTcpSink.cs
@@ -13,6 +13,7 @@ using System.Net.Sockets;
 using System.Runtime.InteropServices;
 using System.Security.Authentication;
 using System.Security.Cryptography.X509Certificates;
+using System.Threading;
 using System.Threading.Tasks;
 using Serilog.Debugging;
 using Serilog.Events;
@@ -190,8 +191,54 @@ namespace Serilog.Sinks.Syslog
             // Authenticate the client, using the provided client certificate if required
             // Note: this method takes an X509CertificateCollection, rather than an X509Certificate,
             // but providing the full chain does not actually appear to work for many servers
-            await sslStream.AuthenticateAsClientAsync(this.Host, this.clientCert,
-                this.secureProtocols, this.checkCertificateRevocation).ConfigureAwait(false);
+            //
+            // Asynchronous calls do not have a default timeout period like most of their synchronous
+            // counterparts do. The AuthenticateAsClientAsync() method initiates the TLS handshake,
+            // which requires sending AND receiving data from the server. If the server is just a plain
+            // socket listener that doesn't have TLS enabled, then it's possible that this method call
+            // will wait forever. For example, if you run the Syslog Watcher server program on Windows,
+            // it does not support TLS. However, it will gladly accept the TCP connection and the TLS
+            // handshake data and not send anything in response. Therefore, this method will wait forever,
+            // giving no indication that anything is wrong. So, we'll implement our own timeout that,
+            // when elapsed, will dispose of the underlying base stream, causing the call to the
+            // AuthenticateAsClientAsync() method to throw an ObjectDisposedException, breaking it out
+            // of the asynchronous wait. We'll use 100 seconds, which is the same as the default timeout
+            // for a WebRequest under a similar condition.
+            var timeoutCts = new CancellationTokenSource(TimeSpan.FromSeconds(100));
+
+            using (timeoutCts)
+            using (timeoutCts.Token.Register(() => { sslStream.Dispose(); baseStream.Dispose(); }))
+            {
+                try
+                {
+                    // Note that with the .NET 5.0 version of this method and .NET Core 2.1+ of this
+                    // method, a cancellation token can be passed directly in as a parameter.
+                    await sslStream.AuthenticateAsClientAsync(this.Host, this.clientCert,
+                        this.secureProtocols, this.checkCertificateRevocation).ConfigureAwait(false);
+
+                    // There is a race condition to this point and when the cancellation token's callback
+                    // may be called versus when we're able to dispose of it to prevent the callback.
+                }
+                catch (ObjectDisposedException)
+                {
+                    // We'd throw the same exception here as we have below in the race condition check,
+                    // so we can just ignore it here for now.
+                }
+            }
+
+            // To mitigate the above mentioned race condition, we can check the cancellation token here
+            // as well and error on the side of caution. If the token has been canceled, then we will not
+            // proceed.
+            if (timeoutCts.IsCancellationRequested)
+            {
+                // This may have already been done by the cancellation token's callback, but in case
+                // we get here due to the race condition, we need to do it and there is no harm in
+                // doing it twice.
+                sslStream.Dispose();
+                baseStream.Dispose();
+
+                throw new OperationCanceledException("Timeout while performing TLS authentication. Check to make sure the server is configured to handle TLS connections.");
+            }
 
             if (!sslStream.IsAuthenticated)
                 throw new AuthenticationException("Unable to authenticate secure syslog server");
@@ -214,7 +261,7 @@ namespace Serilog.Sinks.Syslog
         /// <summary>
         /// Attempt to provide meaningful diagnostic messages for common connection problems
         /// </summary>
-        /// <param name="ex">The exception that occured during the failed connection attempt</param>
+        /// <param name="ex">The exception that occurred during the failed connection attempt</param>
         private void HandleConnectError(Exception ex)
         {
             var prefix = $"[{nameof(SyslogTcpSink)}]";

--- a/src/Serilog.Sinks.Syslog/Sinks/SyslogTcpSink.cs
+++ b/src/Serilog.Sinks.Syslog/Sinks/SyslogTcpSink.cs
@@ -37,6 +37,7 @@ namespace Serilog.Sinks.Syslog
         private readonly X509Certificate2Collection clientCert;
         private readonly RemoteCertificateValidationCallback certValidationCallback;
         private readonly bool checkCertificateRevocation;
+        private readonly TimeSpan tlsAuthenticationTimeout;
 
         public string Host { get; }
         public int Port { get; }
@@ -53,6 +54,7 @@ namespace Serilog.Sinks.Syslog
             this.useTls = config.SecureProtocols != SslProtocols.None;
             this.certValidationCallback = config.CertValidationCallback;
             this.checkCertificateRevocation = config.CheckCertificateRevocation;
+            this.tlsAuthenticationTimeout = config.TlsAuthenticationTimeout;
 
             if (config.CertProvider?.Certificate != null)
             {
@@ -204,7 +206,7 @@ namespace Serilog.Sinks.Syslog
             // AuthenticateAsClientAsync() method to throw an ObjectDisposedException, breaking it out
             // of the asynchronous wait. We'll use 100 seconds, which is the same as the default timeout
             // for a WebRequest under a similar condition.
-            var timeoutCts = new CancellationTokenSource(TimeSpan.FromSeconds(100));
+            var timeoutCts = new CancellationTokenSource(this.tlsAuthenticationTimeout);
 
             using (timeoutCts)
             using (timeoutCts.Token.Register(() => { sslStream.Dispose(); baseStream.Dispose(); }))

--- a/test/Serilog.Sinks.Syslog.Tests/TcpSyslogSinkTests.cs
+++ b/test/Serilog.Sinks.Syslog.Tests/TcpSyslogSinkTests.cs
@@ -113,6 +113,7 @@ namespace Serilog.Sinks.Syslog.Tests
 
             this.tcpConfig.Host = IPAddress.Loopback.ToString();
             this.tcpConfig.Port = receiver.IPEndPoint.Port;
+            this.tcpConfig.TlsAuthenticationTimeout = TimeSpan.FromSeconds(5);
 
             var sink = new SyslogTcpSink(this.tcpConfig);
 

--- a/test/Serilog.Sinks.Syslog.Tests/TcpSyslogSinkTests.cs
+++ b/test/Serilog.Sinks.Syslog.Tests/TcpSyslogSinkTests.cs
@@ -3,10 +3,10 @@
 // Version 2.0. You may obtain a copy of the License at
 // http://www.apache.org/licenses/LICENSE-2.0
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
-using System.Net.NetworkInformation;
 using System.Security.Authentication;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading;
@@ -96,6 +96,29 @@ namespace Serilog.Sinks.Syslog.Tests
             // The sink should have seen the server's certificate in the validation callback
             this.serverCertificate.Thumbprint
                 .ShouldBe(ServerCert.Thumbprint, StringCompareShould.IgnoreCase);
+
+            sink.Dispose();
+            this.cts.Cancel();
+        }
+
+        [Fact]
+        public async Task Should_timeout_when_attempting_secure_tcp_to_non_secure_syslog_service()
+        {
+            // This is all that is needed for the client to attempt to initiate a TLS connection.
+            this.tcpConfig.SecureProtocols = SECURE_PROTOCOLS;
+
+            // As for the server, note that we aren't passing in the server certificate and we're
+            // instructing it to just listen and read and ignore any data.
+            var receiver = new TcpSyslogReceiver(null, SECURE_PROTOCOLS, this.cts.Token, true);
+
+            this.tcpConfig.Host = IPAddress.Loopback.ToString();
+            this.tcpConfig.Port = receiver.IPEndPoint.Port;
+
+            var sink = new SyslogTcpSink(this.tcpConfig);
+
+            var logEvents = Some.LogEvents(3);
+
+            await Assert.ThrowsAsync<OperationCanceledException>(async () => await sink.EmitBatchAsync(logEvents));
 
             sink.Dispose();
             this.cts.Cancel();


### PR DESCRIPTION
See Issue #18. Implement a timeout wrapper around the call to the SslStream.AuthenticateAsClientAsync() because it doesn't take in a cancellation token itself. If the client attempts to connect to a server that does not implement TLS, a call to this method may wait forever because the server won't send back any data for the TLS handshake that this method is expecting. We'll use 100 seconds, which is the same as the default timeout for a WebRequest under a similar condition.

Here are the Unit Tests on Windows. Note, for testing I manually changed the hard coded timeout value to just 10 seconds.
![image](https://user-images.githubusercontent.com/22459191/108023337-8a15b280-6fdf-11eb-9e40-26bd517a89b8.png)
And here are the tests on Ubuntu 20.
![image](https://user-images.githubusercontent.com/22459191/108023411-b0d3e900-6fdf-11eb-90f0-77e823bd78d1.png)
