### PR TITLE
RFC5424: choose custom msgId provider (other than "SourceContext")

### DIFF
--- a/src/Serilog.Sinks.Syslog/Sinks/Formatters/LocalFormatter.cs
+++ b/src/Serilog.Sinks.Syslog/Sinks/Formatters/LocalFormatter.cs
@@ -16,6 +16,12 @@ namespace Serilog.Sinks.Syslog
     /// </summary>
     public class LocalFormatter : SyslogFormatterBase
     {
+        /// <summary>
+        /// Initialize a new instance of <see cref="LocalFormatter"/> class allowing you to specify values for
+        /// the facility, application name and template formatter.
+        /// </summary>
+        /// <param name="facility">One of the <see cref="Facility"/> values indicating the machine process that created the syslog event. Defaults to <see cref="Facility.Local0"/>.</param>
+        /// <param name="templateFormatter">See <see cref="Formatting.ITextFormatter"/>.</param>
         public LocalFormatter(Facility facility = Facility.Local0,
             MessageTemplateTextFormatter templateFormatter = null)
             : base(facility, templateFormatter) { }

--- a/src/Serilog.Sinks.Syslog/Sinks/Formatters/Rfc3164Formatter.cs
+++ b/src/Serilog.Sinks.Syslog/Sinks/Formatters/Rfc3164Formatter.cs
@@ -19,6 +19,13 @@ namespace Serilog.Sinks.Syslog
     {
         private readonly string applicationName;
 
+        /// <summary>
+        /// Initialize a new instance of <see cref="Rfc3164Formatter"/> class allowing you to specify values for
+        /// the facility, application name and template formatter.
+        /// </summary>
+        /// <param name="facility">One of the <see cref="Facility"/> values indicating the machine process that created the syslog event. Defaults to <see cref="Facility.Local0"/>.</param>
+        /// <param name="applicationName">A user supplied value representing the application name that will appear in the syslog event. Must be all printable ASCII characters. Max length 32. Defaults to the current process name.</param>
+        /// <param name="templateFormatter">See <see cref="Formatting.ITextFormatter"/>.</param>
         public Rfc3164Formatter(Facility facility = Facility.Local0, string applicationName = null,
             MessageTemplateTextFormatter templateFormatter = null)
             : base(facility, templateFormatter)

--- a/src/Serilog.Sinks.Syslog/Sinks/Formatters/Rfc5424Formatter.cs
+++ b/src/Serilog.Sinks.Syslog/Sinks/Formatters/Rfc5424Formatter.cs
@@ -39,9 +39,11 @@ namespace Serilog.Sinks.Syslog
         private const string DATE_FORMAT = "yyyy'-'MM'-'dd'T'HH':'mm':'ss.ffffffzzz";
 
         private readonly string applicationName;
+        private readonly string messageIdPropertyName;
 
         public Rfc5424Formatter(Facility facility = Facility.Local0, string applicationName = null,
-            MessageTemplateTextFormatter templateFormatter = null)
+            MessageTemplateTextFormatter templateFormatter = null,
+            string messageIdPropertyName = null)
             : base(facility, templateFormatter)
         {
             this.applicationName = applicationName ?? ProcessName;
@@ -50,6 +52,7 @@ namespace Serilog.Sinks.Syslog
             this.applicationName = this.applicationName
                 .AsPrintableAscii()
                 .WithMaxLength(48);
+            this.messageIdPropertyName = messageIdPropertyName ?? "SourceContext";
         }
 
         // NOTE: For the rsyslog daemon to correctly handle RFC5424, you need to change your /etc/rsyslog.conf to use:
@@ -73,9 +76,9 @@ namespace Serilog.Sinks.Syslog
         /// </summary>
         /// <param name="logEvent">The LogEvent to extract the context from</param>
         /// <returns>The processed SourceContext, or NILVALUE '-' if not set</returns>
-        private static string GetMessageId(LogEvent logEvent)
+        private string GetMessageId(LogEvent logEvent)
         {
-            var hasMsgId = logEvent.Properties.TryGetValue("SourceContext", out LogEventPropertyValue propertyValue);
+            var hasMsgId = logEvent.Properties.TryGetValue(this.messageIdPropertyName, out LogEventPropertyValue propertyValue);
 
             if (!hasMsgId)
                 return NILVALUE;

--- a/src/Serilog.Sinks.Syslog/Sinks/Formatters/Rfc5424Formatter.cs
+++ b/src/Serilog.Sinks.Syslog/Sinks/Formatters/Rfc5424Formatter.cs
@@ -41,9 +41,17 @@ namespace Serilog.Sinks.Syslog
         private readonly string applicationName;
         private readonly string messageIdPropertyName;
 
+        /// <summary>
+        /// Initialize a new instance of <see cref="Rfc5424Formatter"/> class allowing you to specify values for
+        /// the facility, application name, template formatter, and message Id property name.
+        /// </summary>
+        /// <param name="facility">One of the <see cref="Facility"/> values indicating the machine process that created the syslog event. Defaults to <see cref="Facility.Local0"/>.</param>
+        /// <param name="applicationName">A user supplied value representing the application name that will appear in the syslog event. Must be all printable ASCII characters. Max length 48. Defaults to the current process name.</param>
+        /// <param name="templateFormatter">See <see cref="Formatting.ITextFormatter"/>.</param>
+        /// <param name="messageIdPropertyName">Where the Id number of the message will be derived from. Defaults to the "SourceContext" property of the syslog event. Property name and value must be all printable ASCII characters with max length of 32.</param>
         public Rfc5424Formatter(Facility facility = Facility.Local0, string applicationName = null,
             MessageTemplateTextFormatter templateFormatter = null,
-            string messageIdPropertyName = null)
+            string messageIdPropertyName = "SourceContext")
             : base(facility, templateFormatter)
         {
             this.applicationName = applicationName ?? ProcessName;
@@ -52,7 +60,11 @@ namespace Serilog.Sinks.Syslog
             this.applicationName = this.applicationName
                 .AsPrintableAscii()
                 .WithMaxLength(48);
-            this.messageIdPropertyName = messageIdPropertyName ?? "SourceContext";
+
+            // Conform to the RFC
+            this.messageIdPropertyName = messageIdPropertyName
+                                         .AsPrintableAscii()
+                                         .WithMaxLength(32);
         }
 
         // NOTE: For the rsyslog daemon to correctly handle RFC5424, you need to change your /etc/rsyslog.conf to use:

--- a/src/Serilog.Sinks.Syslog/SyslogLoggerConfigurationExtensions.cs
+++ b/src/Serilog.Sinks.Syslog/SyslogLoggerConfigurationExtensions.cs
@@ -129,6 +129,7 @@ namespace Serilog
         /// </param>
         /// <param name="outputTemplate">A message template describing the output messages</param>
         /// <param name="restrictedToMinimumLevel">The minimum level for events passed through the sink</param>
+        /// <param name="messageIdPropertyName">Log data property to use for the syslog msgId</param>
         /// <seealso cref="!:https://github.com/serilog/serilog/wiki/Formatting-Output"/>
         public static LoggerConfiguration TcpSyslog(this LoggerSinkConfiguration loggerSinkConfig,
             string host, int port = 1468, string appName = null, FramingType framingType = FramingType.OCTET_COUNTING,
@@ -136,9 +137,10 @@ namespace Serilog
             SslProtocols secureProtocols = SslProtocols.Tls12, ICertificateProvider certProvider = null,
             RemoteCertificateValidationCallback certValidationCallback = null,
             string outputTemplate = null,
-            LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum)
+            LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
+            string messageIdPropertyName = null)
         {
-            var formatter = GetFormatter(format, appName, facility, outputTemplate);
+            var formatter = GetFormatter(format, appName, facility, outputTemplate, messageIdPropertyName);
 
             var config = new SyslogTcpConfig
             {
@@ -155,7 +157,8 @@ namespace Serilog
         }
 
         private static ISyslogFormatter GetFormatter(SyslogFormat format, string appName, Facility facility,
-            string outputTemplate)
+            string outputTemplate,
+            string messageIdPropertyName = null)
         {
             var templateFormatter = String.IsNullOrWhiteSpace(outputTemplate)
                 ? null
@@ -164,7 +167,7 @@ namespace Serilog
             return format switch
             {
                 SyslogFormat.RFC3164 => new Rfc3164Formatter(facility, appName, templateFormatter),
-                SyslogFormat.RFC5424 => new Rfc5424Formatter(facility, appName, templateFormatter),
+                SyslogFormat.RFC5424 => new Rfc5424Formatter(facility, appName, templateFormatter, messageIdPropertyName),
                 SyslogFormat.Local => new LocalFormatter(facility, templateFormatter),
                 _ => throw new ArgumentException($"Invalid format: {format}")
             };

--- a/src/Serilog.Sinks.Syslog/SyslogLoggerConfigurationExtensions.cs
+++ b/src/Serilog.Sinks.Syslog/SyslogLoggerConfigurationExtensions.cs
@@ -62,7 +62,7 @@ namespace Serilog
         /// <param name="loggerSinkConfig">The logger configuration</param>
         /// <param name="host">Hostname of the syslog server</param>
         /// <param name="port">Port the syslog server is listening on</param>
-        /// <param name="appName">The name of the application. Defaults to the current process name</param>
+        /// <param name="appName">The name of the application. Must be all printable ASCII characters. Max length 32 (for RFC3164) or 48 (for RFC5424). Defaults to the current process name</param>
         /// <param name="format">The syslog message format to be used</param>
         /// <param name="facility">The category of the application</param>
         /// <param name="batchConfig">Batching configuration</param>
@@ -115,7 +115,7 @@ namespace Serilog
         /// <param name="loggerSinkConfig">The logger configuration</param>
         /// <param name="host">Hostname of the syslog server</param>
         /// <param name="port">Port the syslog server is listening on</param>
-        /// <param name="appName">The name of the application. Defaults to the current process name</param>
+        /// <param name="appName">The name of the application. Must be all printable ASCII characters. Max length 32 (for RFC3164) or 48 (for RFC5424). Defaults to the current process name</param>
         /// <param name="framingType">How to frame/delimit syslog messages for the wire</param>
         /// <param name="format">The syslog message format to be used</param>
         /// <param name="facility">The category of the application</param>
@@ -129,7 +129,7 @@ namespace Serilog
         /// </param>
         /// <param name="outputTemplate">A message template describing the output messages</param>
         /// <param name="restrictedToMinimumLevel">The minimum level for events passed through the sink</param>
-        /// <param name="messageIdPropertyName">Log data property to use for the syslog msgId</param>
+        /// <param name="messageIdPropertyName">Where the Id number of the message will be derived from. Defaults to the "SourceContext" property of the syslog event. Property name and value must be all printable ASCII characters with max length of 32.</param>
         /// <seealso cref="!:https://github.com/serilog/serilog/wiki/Formatting-Output"/>
         public static LoggerConfiguration TcpSyslog(this LoggerSinkConfiguration loggerSinkConfig,
             string host, int port = 1468, string appName = null, FramingType framingType = FramingType.OCTET_COUNTING,

--- a/test/Serilog.Sinks.Syslog.Tests/Formatters/SyslogRfc5424FormatterTests.cs
+++ b/test/Serilog.Sinks.Syslog.Tests/Formatters/SyslogRfc5424FormatterTests.cs
@@ -107,7 +107,7 @@ namespace Serilog.Sinks.Syslog.Tests
             const string testProperty = "AProperty";
             const string testVal = "AValue";
             const string msgIdPropertyName = testProperty;
-            Rfc5424Formatter customFormatter = new Rfc5424Formatter(Facility.User, APP_NAME,null, msgIdPropertyName);
+            var customFormatter = new Rfc5424Formatter(Facility.User, APP_NAME, null, msgIdPropertyName);
 
             var properties = new List<LogEventProperty>
             {


### PR DESCRIPTION
By default the sink uses the "SourceContext" property from the log data to generate the syslog message id. 
I would like to choose an alternative property for syslog message id generation.

What do you think about this solution?