### PR TITLE
Issue #40: Invalid log levels

### DIFF
--- a/src/Serilog.Sinks.Syslog/Sinks/Formatters/LocalFormatter.cs
+++ b/src/Serilog.Sinks.Syslog/Sinks/Formatters/LocalFormatter.cs
@@ -3,6 +3,7 @@
 // Version 2.0. You may obtain a copy of the License at
 // http://www.apache.org/licenses/LICENSE-2.0
 
+using System;
 using Serilog.Events;
 using Serilog.Formatting.Display;
 
@@ -20,11 +21,13 @@ namespace Serilog.Sinks.Syslog
         /// Initialize a new instance of <see cref="LocalFormatter"/> class allowing you to specify values for
         /// the facility, application name and template formatter.
         /// </summary>
-        /// <param name="facility">One of the <see cref="Facility"/> values indicating the machine process that created the syslog event. Defaults to <see cref="Facility.Local0"/>.</param>
-        /// <param name="templateFormatter">See <see cref="Formatting.ITextFormatter"/>.</param>
+        /// <param name="facility"><inheritdoc cref="Facility" path="/summary"/></param>
+        /// <param name="templateFormatter"><inheritdoc cref="SyslogFormatterBase.templateFormatter" path="/summary"/></param>
+        /// <param name="severityMapping"><inheritdoc cref="SyslogLoggerConfigurationExtensions.LocalSyslog" path="/param[@name='severityMapping']"/></param>
         public LocalFormatter(Facility facility = Facility.Local0,
-            MessageTemplateTextFormatter templateFormatter = null)
-            : base(facility, templateFormatter) { }
+            MessageTemplateTextFormatter templateFormatter = null,
+            Func<LogEventLevel, Severity> severityMapping = null)
+            : base(facility, templateFormatter, severityMapping: severityMapping) { }
 
         public override string FormatMessage(LogEvent logEvent)
             => RenderMessage(logEvent);

--- a/src/Serilog.Sinks.Syslog/Sinks/Formatters/Rfc3164Formatter.cs
+++ b/src/Serilog.Sinks.Syslog/Sinks/Formatters/Rfc3164Formatter.cs
@@ -23,14 +23,16 @@ namespace Serilog.Sinks.Syslog
         /// Initialize a new instance of <see cref="Rfc3164Formatter"/> class allowing you to specify values for
         /// the facility, application name and template formatter.
         /// </summary>
-        /// <param name="facility">One of the <see cref="Facility"/> values indicating the machine process that created the syslog event. Defaults to <see cref="Facility.Local0"/>.</param>
+        /// <param name="facility"><inheritdoc cref="Facility" path="/summary"/></param>
         /// <param name="applicationName">A user supplied value representing the application name that will appear in the syslog event. Must be all printable ASCII characters. Max length 32. Defaults to the current process name.</param>
-        /// <param name="templateFormatter">See <see cref="Formatting.ITextFormatter"/>.</param>
-        /// <param name="sourceHost">Overrides the Hostname value in the syslog packet header. Max length 255. Defaults to Environment.MachineName.</param>
+        /// <param name="templateFormatter"><inheritdoc cref="SyslogFormatterBase.templateFormatter" path="/summary"/></param>
+        /// <param name="sourceHost"><inheritdoc cref="SyslogFormatterBase.Host" path="/summary"/></param>
+        /// <param name="severityMapping"><inheritdoc cref="SyslogLoggerConfigurationExtensions.LocalSyslog" path="/param[@name='severityMapping']"/></param>
         public Rfc3164Formatter(Facility facility = Facility.Local0, string applicationName = null,
             MessageTemplateTextFormatter templateFormatter = null,
-            string sourceHost = null)
-            : base(facility, templateFormatter, sourceHost)
+            string sourceHost = null,
+            Func<LogEventLevel, Severity> severityMapping = null)
+            : base(facility, templateFormatter, sourceHost, severityMapping)
         {
             this.applicationName = applicationName ?? ProcessName;
 

--- a/src/Serilog.Sinks.Syslog/Sinks/Formatters/Rfc5424Formatter.cs
+++ b/src/Serilog.Sinks.Syslog/Sinks/Formatters/Rfc5424Formatter.cs
@@ -47,16 +47,18 @@ namespace Serilog.Sinks.Syslog
         /// Initialize a new instance of <see cref="Rfc5424Formatter"/> class allowing you to specify values for
         /// the facility, application name, template formatter, and message Id property name.
         /// </summary>
-        /// <param name="facility">One of the <see cref="Facility"/> values indicating the machine process that created the syslog event. Defaults to <see cref="Facility.Local0"/>.</param>
+        /// <param name="facility"><inheritdoc cref="Facility" path="/summary"/></param>
         /// <param name="applicationName">A user supplied value representing the application name that will appear in the syslog event. Must be all printable ASCII characters. Max length 48. Defaults to the current process name.</param>
-        /// <param name="templateFormatter">See <see cref="Formatting.ITextFormatter"/>.</param>
+        /// <param name="templateFormatter"><inheritdoc cref="SyslogFormatterBase.templateFormatter" path="/summary"/></param>
         /// <param name="messageIdPropertyName">Where the Id number of the message will be derived from. Defaults to the "SourceContext" property of the syslog event. Property name and value must be all printable ASCII characters with max length of 32.</param>
-        /// <param name="sourceHost">Overrides the Host value in the syslog data packet. Defaults to Environment.MachineName when empty.</param>
+        /// <param name="sourceHost"><inheritdoc cref="SyslogFormatterBase.Host" path="/summary"/></param>
+        /// <param name="severityMapping"><inheritdoc cref="SyslogLoggerConfigurationExtensions.LocalSyslog" path="/param[@name='severityMapping']"/></param>
         public Rfc5424Formatter(Facility facility = Facility.Local0, string applicationName = null,
             MessageTemplateTextFormatter templateFormatter = null,
             string messageIdPropertyName = DefaultMessageIdPropertyName,
-            string sourceHost = null)
-            : base(facility, templateFormatter, sourceHost)
+            string sourceHost = null,
+            Func<LogEventLevel, Severity> severityMapping = null)
+            : base(facility, templateFormatter, sourceHost, severityMapping)
         {
             this.applicationName = applicationName ?? ProcessName;
 

--- a/src/Serilog.Sinks.Syslog/Sinks/Formatters/SyslogFormatterBase.cs
+++ b/src/Serilog.Sinks.Syslog/Sinks/Formatters/SyslogFormatterBase.cs
@@ -20,19 +20,35 @@ namespace Serilog.Sinks.Syslog
     /// </remarks>
     public abstract class SyslogFormatterBase : ISyslogFormatter
     {
-        private readonly Facility facility;
-        private readonly MessageTemplateTextFormatter templateFormatter;
+        protected readonly Facility facility;
+
+        /// <summary>See <see cref="Formatting.ITextFormatter"/>.</summary>
+        protected readonly MessageTemplateTextFormatter templateFormatter;
+
+        /// <summary><inheritdoc cref="SyslogLoggerConfigurationExtensions.LocalSyslog" path="/param[@name='severityMapping']"/></summary>
+        protected readonly Func<LogEventLevel, Severity> severityMapping;
+
+        /// <summary>Overrides the Hostname value in the syslog packet header. Max length 255. Defaults to <c>Environment.MachineName</c>.</summary>
         protected readonly string Host;
         protected static readonly string ProcessId = Process.GetCurrentProcess().Id.ToString();
         protected static readonly string ProcessName = Process.GetCurrentProcess().ProcessName;
 
+        /// <summary>
+        /// Common functionality for a derived syslog formatter class.
+        /// </summary>
+        /// <param name="facility"><inheritdoc cref="Facility" path="/summary"/></param>
+        /// <param name="templateFormatter"><inheritdoc cref="templateFormatter" path="/summary"/></param>
+        /// <param name="sourceHost"><inheritdoc cref="Host" path="/summary"/></param>
+        /// <param name="severityMapping"><inheritdoc cref="SyslogLoggerConfigurationExtensions.LocalSyslog" path="/param[@name='severityMapping']"/></param>
         protected SyslogFormatterBase(
             Facility facility,
             MessageTemplateTextFormatter templateFormatter,
-            string sourceHost = null)
+            string sourceHost = null,
+            Func<LogEventLevel, Severity> severityMapping = null)
         {
             this.facility = facility;
             this.templateFormatter = templateFormatter;
+            this.severityMapping = severityMapping ?? DefaultLogLevelToSeverityMap;
 
             // Use source hostname override, if specified
             this.Host = String.IsNullOrEmpty(sourceHost)
@@ -42,20 +58,28 @@ namespace Serilog.Sinks.Syslog
 
         public abstract string FormatMessage(LogEvent logEvent);
 
-        public int CalculatePriority(LogEventLevel level)
+        public virtual int CalculatePriority(LogEventLevel level)
         {
-            var severity = MapLogLevelToSeverity(level);
+            var severity = this.severityMapping(level);
             return ((int)this.facility * 8) + (int)severity;
         }
 
-        private static Severity MapLogLevelToSeverity(LogEventLevel logEventLevel)
+        /// <summary>This is the original/default mapping between the available Serilog <see cref="LogEventLevel"/>s
+        /// and those offered by the syslog <see cref="Severity"/>. Unfortunately, there is not a one-to-one mapping.
+        /// So this method performs the mapping based on having most of the names between the two match.
+        /// <para>One thing to note is that this mapping will cause the Serilog <see cref="LogEventLevel.Verbose"/>
+        /// to be mapped to <see cref="Severity.Notice"/>, which doesn't match the typical relative importance
+        /// between the two.</para></summary>
+        /// <param name="logEventLevel">A Serilog <see cref="LogEventLevel"/>.</param>
+        /// <returns>A syslog <see cref="Severity"/>.</returns>
+        private static Severity DefaultLogLevelToSeverityMap(LogEventLevel logEventLevel)
             => logEventLevel switch
             {
                 LogEventLevel.Debug => Severity.Debug,
-                LogEventLevel.Error => Severity.Error,
-                LogEventLevel.Fatal => Severity.Emergency,
                 LogEventLevel.Information => Severity.Informational,
                 LogEventLevel.Warning => Severity.Warning,
+                LogEventLevel.Error => Severity.Error,
+                LogEventLevel.Fatal => Severity.Emergency,
                 _ => Severity.Notice
             };
 

--- a/src/Serilog.Sinks.Syslog/Sinks/Settings/Facility.cs
+++ b/src/Serilog.Sinks.Syslog/Sinks/Settings/Facility.cs
@@ -6,7 +6,7 @@
 namespace Serilog.Sinks.Syslog
 {
     /// <summary>
-    /// The category of the system or application that generated a syslog message
+    /// A value used to categorize the system or application that generated the syslog event.
     /// </summary>
     public enum Facility
     {

--- a/test/Serilog.Sinks.Syslog.Tests/LocalSyslogSinkTests.cs
+++ b/test/Serilog.Sinks.Syslog.Tests/LocalSyslogSinkTests.cs
@@ -3,7 +3,9 @@
 // Version 2.0. You may obtain a copy of the License at
 // http://www.apache.org/licenses/LICENSE-2.0
 
+using System;
 using FakeItEasy;
+using Serilog.Events;
 using Xunit;
 using static Serilog.Sinks.Syslog.Tests.Fixture;
 
@@ -31,6 +33,74 @@ namespace Serilog.Sinks.Syslog.Tests
             A.CallTo(() => syslogService.Open()).MustHaveHappened();
             A.CallTo(() => syslogService.WriteLog(134, A<string>.That.EndsWith("This is a test message"))).MustHaveHappened();
             A.CallTo(() => syslogService.Close()).MustHaveHappened();
+        }
+
+        [Fact]
+        public void Should_override_severity_with_alternate_severityMapping()
+        {
+            const string msg = "The mapping of Serilog EventLogLevel.Verbose has been overridden to Syslog Severity.Debug.";
+
+            var syslogFormatter = new Rfc3164Formatter(Facility.Local0, "TestApp",
+                severityMapping: level => SyslogLoggerConfigurationExtensions.ValueBasedLogLevelToSeverityMap(level));
+
+            var syslogService = A.Fake<LocalSyslogService>();
+            var sink = new SyslogLocalSink(syslogFormatter, syslogService);
+
+            var log = new LoggerConfiguration()
+                .WriteTo.Sink(sink).MinimumLevel.Verbose()
+                .CreateLogger();
+
+            log.Verbose(msg);
+
+            sink.Dispose();
+
+            // With the custom severity mapping and a Facility of Local0, the calculated priority should be:
+            // Local0 * 8 + Severity.Debug = 16 * 8 + 7 = 135
+            A.CallTo(() => syslogService.Open()).MustHaveHappened();
+            A.CallTo(() => syslogService.WriteLog(135, A<string>.That.EndsWith(msg))).MustHaveHappened();
+            A.CallTo(() => syslogService.Close()).MustHaveHappened();
+        }
+
+        [Fact]
+        public void Should_override_severity()
+        {
+            const string msg = "The mapping of Serilog EventLogLevel.Fatal has been overridden to Syslog Severity.Critical.";
+            var syslogFormatter = new CustomSeverityMapping();
+            var syslogService = A.Fake<LocalSyslogService>();
+            var sink = new SyslogLocalSink(syslogFormatter, syslogService);
+
+            var log = GetLogger(sink);
+
+            log.Fatal(msg);
+
+            sink.Dispose();
+
+            A.CallTo(() => syslogService.Open()).MustHaveHappened();
+
+            // With the custom severity mapping and a Facility of Local0, the calculated priority should be:
+            // Local0 * 8 + Severity.Critical = 16 * 8 + 2 = 130
+            A.CallTo(() => syslogService.WriteLog(130, A<string>.That.EndsWith(msg))).MustHaveHappened();
+            A.CallTo(() => syslogService.Close()).MustHaveHappened();
+        }
+
+        private class CustomSeverityMapping : LocalFormatter
+        {
+            public CustomSeverityMapping() : base(Facility.Local0, null,
+                severityMapping: level =>
+                    level switch
+                    {
+                        LogEventLevel.Verbose => Severity.Debug,
+                        LogEventLevel.Debug => Severity.Debug,
+                        LogEventLevel.Information => Severity.Informational,
+                        LogEventLevel.Warning => Severity.Warning,
+                        LogEventLevel.Error => Severity.Error,
+                        LogEventLevel.Fatal => Severity.Critical,
+                        _ => throw new ArgumentOutOfRangeException(nameof(level), $"The value {level} is not a valid LogEventLevel.")
+                    }
+                )
+            {
+
+            }
         }
     }
 }


### PR DESCRIPTION
A new parameter to allow for a callback method that can be used to provide alternative mappings from Serilog `EventLogLevel` to Syslog `Severity`.

Offer a public alternate severity mapping that can be used as the new parameter value instead of having to write your own method.

Expose `SyslogFormatterBase.CalculatePriority()` as `virtual` so someone can easily override it and have complete control.