### PR TITLE
Configuration Example Using App.config

### DIFF
--- a/sample/Serilog.Sinks.Syslog.ConfigSample/App.config
+++ b/sample/Serilog.Sinks.Syslog.ConfigSample/App.config
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+  <appSettings>
+    <!-- The following is equivalent to:
+    
+    Log.Logger = new LoggerConfiguration()
+      .MinimumLevel.Verbose()
+      .WriteTo.UdpSyslog(host: "localhost", port: 514, sourceHost: "appSettings")
+      .CreateLogger();
+    -->
+    <add key="serilog:minimum-level" value="Verbose" />
+    <add key="serilog:using:UdpSyslog" value="Serilog.Sinks.Syslog" />
+    <add key="serilog:write-to:UdpSyslog" />
+    <add key="serilog:write-to:UdpSyslog.host" value="localhost" />
+    <add key="serilog:write-to:UdpSyslog.port" value="514" />
+    <add key="serilog:write-to:UdpSyslog.sourceHost" value="appSettings" />
+  </appSettings>
+</configuration>

--- a/sample/Serilog.Sinks.Syslog.ConfigSample/Program.cs
+++ b/sample/Serilog.Sinks.Syslog.ConfigSample/Program.cs
@@ -21,8 +21,12 @@ namespace Serilog.Sinks.Syslog.Sample
                 .AddJsonFile("appsettings.json")
                 .Build();
 
+            // Examples for both reading configuration from a JSON configuration file and
+            // an App.config/web.config file. The latter requiring the Serilog.Settings.AppSettings
+            // NuGet package. See https://github.com/serilog/serilog/wiki/AppSettings
             Log.Logger = new LoggerConfiguration()
                 .ReadFrom.Configuration(config)
+                .ReadFrom.AppSettings()
                 .CreateLogger();
 
             SelfLog.Enable(Console.Error);
@@ -36,10 +40,10 @@ namespace Serilog.Sinks.Syslog.Sample
                 cts.Cancel();
             };
 
+            Console.WriteLine("Press CTRL-C to stop");
             await WriteLogs(cts.Token);
 
             // Blocks here waiting for CTRL-C
-            Console.WriteLine("Press CTRL-C to stop");
             cts.Token.WaitHandle.WaitOne();
 
             Log.CloseAndFlush();

--- a/sample/Serilog.Sinks.Syslog.ConfigSample/Serilog.Sinks.Syslog.ConfigSample.csproj
+++ b/sample/Serilog.Sinks.Syslog.ConfigSample/Serilog.Sinks.Syslog.ConfigSample.csproj
@@ -20,6 +20,8 @@
     <PackageReference Include="Microsoft.NETCore.Targets" Version="3.0.0" PrivateAssets="all" />
 
     <PackageReference Include="Serilog" Version="2.6.0" />
+
+    <PackageReference Include="Serilog.Settings.AppSettings" Version="2.2.2" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="3.1.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.16" />


### PR DESCRIPTION
An issue was asked, #50, about using the Syslog sink from a web.config file. Serilog supports doing this by includng the `Serilog.Settings.AppSettings` package from NuGet and calling the `.ReadFrom.AppSettings()` extension method. See https://github.com/serilog/serilog/wiki/AppSettings for more details.

We will extend this example project to also include a sample `App.config` file demonstrating the usage of the `.ReadFrom.AppSettings()`.

![image](https://user-images.githubusercontent.com/22459191/158030981-c56876cd-b044-490b-b66f-48d5075eb81e.png)
