### PR TITLE
Fix NRE caused when LocalSyslog is unavailable

### DIFF
--- a/src/Serilog.Sinks.Syslog/Sinks/Internal/NullSink.cs
+++ b/src/Serilog.Sinks.Syslog/Sinks/Internal/NullSink.cs
@@ -1,0 +1,16 @@
+using Serilog.Core;
+using Serilog.Events;
+
+namespace Serilog.Sinks.Internal
+{
+    /// <summary>
+    /// This Sink does nothing
+    /// </summary>
+    internal class NullSink : ILogEventSink
+    {
+        public void Emit(LogEvent logEvent)
+        {
+            //Do nothing
+        }
+    }
+}

--- a/src/Serilog.Sinks.Syslog/SyslogLoggerConfigurationExtensions.cs
+++ b/src/Serilog.Sinks.Syslog/SyslogLoggerConfigurationExtensions.cs
@@ -62,10 +62,8 @@ namespace Serilog
             {
                 SelfLog.WriteLine("The LocalSyslog sink is only supported on Linux systems");
 
-                var loggerSinkConfigurationType = typeof(LoggerSinkConfiguration);
-                var field = loggerSinkConfigurationType.GetField("_loggerConfiguration", BindingFlags.Instance | BindingFlags.NonPublic);
-                Debug.Assert(field != null);
-                return (LoggerConfiguration)field.GetValue(loggerSinkConfig);
+                //Construct a NullSink, https://github.com/serilog/serilog/issues/1670
+                return LoggerSinkConfiguration.Wrap(loggerSinkConfig, wt => wt, _ => { });
             }
 
             var messageFormatter = GetFormatter(SyslogFormat.Local, appName, facility, outputTemplate,

--- a/src/Serilog.Sinks.Syslog/SyslogLoggerConfigurationExtensions.cs
+++ b/src/Serilog.Sinks.Syslog/SyslogLoggerConfigurationExtensions.cs
@@ -4,10 +4,12 @@
 // http://www.apache.org/licenses/LICENSE-2.0
 
 using System;
+using System.Diagnostics;
 using System.Linq;
 using System.Net;
 using System.Net.Security;
 using System.Net.Sockets;
+using System.Reflection;
 using System.Security.Authentication;
 using Serilog.Configuration;
 using Serilog.Debugging;
@@ -59,7 +61,11 @@ namespace Serilog
             if (!LocalSyslogService.IsAvailable)
             {
                 SelfLog.WriteLine("The LocalSyslog sink is only supported on Linux systems");
-                return default;
+
+                var loggerSinkConfigurationType = typeof(LoggerSinkConfiguration);
+                var field = loggerSinkConfigurationType.GetField("_loggerConfiguration", BindingFlags.Instance | BindingFlags.NonPublic);
+                Debug.Assert(field != null);
+                return (LoggerConfiguration)field.GetValue(loggerSinkConfig);
             }
 
             var messageFormatter = GetFormatter(SyslogFormat.Local, appName, facility, outputTemplate,

--- a/src/Serilog.Sinks.Syslog/SyslogLoggerConfigurationExtensions.cs
+++ b/src/Serilog.Sinks.Syslog/SyslogLoggerConfigurationExtensions.cs
@@ -4,18 +4,17 @@
 // http://www.apache.org/licenses/LICENSE-2.0
 
 using System;
-using System.Diagnostics;
 using System.Linq;
 using System.Net;
 using System.Net.Security;
 using System.Net.Sockets;
-using System.Reflection;
 using System.Security.Authentication;
 using Serilog.Configuration;
 using Serilog.Debugging;
 using Serilog.Events;
 using Serilog.Formatting;
 using Serilog.Formatting.Display;
+using Serilog.Sinks.Internal;
 using Serilog.Sinks.PeriodicBatching;
 using Serilog.Sinks.Syslog;
 
@@ -61,11 +60,7 @@ namespace Serilog
             if (!LocalSyslogService.IsAvailable)
             {
                 SelfLog.WriteLine("The LocalSyslog sink is only supported on Linux systems");
-
-                //Construct a NullSink, https://github.com/serilog/serilog/issues/1670
-#pragma warning disable CS0618
-                return LoggerSinkConfiguration.Wrap(loggerSinkConfig, wt => wt, _ => { });
-#pragma warning restore CS0618
+                return loggerSinkConfig.Sink<NullSink>();
             }
 
             var messageFormatter = GetFormatter(SyslogFormat.Local, appName, facility, outputTemplate,

--- a/src/Serilog.Sinks.Syslog/SyslogLoggerConfigurationExtensions.cs
+++ b/src/Serilog.Sinks.Syslog/SyslogLoggerConfigurationExtensions.cs
@@ -63,7 +63,9 @@ namespace Serilog
                 SelfLog.WriteLine("The LocalSyslog sink is only supported on Linux systems");
 
                 //Construct a NullSink, https://github.com/serilog/serilog/issues/1670
+#pragma warning disable CS0618
                 return LoggerSinkConfiguration.Wrap(loggerSinkConfig, wt => wt, _ => { });
+#pragma warning restore CS0618
             }
 
             var messageFormatter = GetFormatter(SyslogFormat.Local, appName, facility, outputTemplate,


### PR DESCRIPTION
Hi, I found out that returning default in ``LocalSyslog`` extension function will throw NRE exception
The current repair method is relatively hack, and another solution is
```csharp
if (!LocalSyslogService.IsAvailable)
            {
                SelfLog.WriteLine("The LocalSyslog sink is only supported on Linux systems");
                 return loggerSinkConfig.Sink(new LoggerConfiguration().CreateLogger());
            }
```

This scheme leads to extra allocation and invalid work, I don't like this way.
Since ``LoggerSinkConfiguration`` doesn't expose a ``_loggerConfiguration`` member, this makes it hard for me to choose.
What do you think?
