### PR TITLE
add AllowIPv6 flag to override IPv6 auto-discovery

### DIFF
--- a/src/Serilog.Sinks.Syslog/Sinks/Settings/SyslogTcpConfig.cs
+++ b/src/Serilog.Sinks.Syslog/Sinks/Settings/SyslogTcpConfig.cs
@@ -55,6 +55,13 @@ namespace Serilog.Sinks.Syslog
         public bool UseTls { get; set; }
 
         /// <summary>
+        /// If <c>true</c>, the sink will use the Socket.OSSupportsIPv6 setting to determine if
+        /// it should connect to the Syslog server using IPv6. If <c>false</c>, it will only use IPv4.
+        /// Defaults to <c>true</c>.
+        /// </summary>
+        public bool AllowIPv6 { get; set; } = true;
+
+        /// <summary>
         /// When <see cref="UseTls"/> is <c>true</c>, CertProvider can be used to present a client certificate
         /// to the syslog server. Leave as null if no client certificate is required
         /// </summary>

--- a/src/Serilog.Sinks.Syslog/Sinks/SyslogTcpSink.cs
+++ b/src/Serilog.Sinks.Syslog/Sinks/SyslogTcpSink.cs
@@ -148,7 +148,11 @@ namespace Serilog.Sinks.Syslog
                 var ipv6Enabled = this.allowIPv6 && Socket.OSSupportsIPv6;
 
                 this.client = new TcpClient(ipv6Enabled ? AddressFamily.InterNetworkV6 : AddressFamily.InterNetwork);
-                this.client.Client.DualMode = ipv6Enabled;
+
+                // Use of dual mode property throws exception if IPv6 is not available
+                if (ipv6Enabled) {
+                    this.client.Client.DualMode = ipv6Enabled;
+                }
 
                 // If the Host name specified is already an IP address, then that is what will be returned.
                 var hostAddresses = await Dns.GetHostAddressesAsync(this.Host).ConfigureAwait(false);

--- a/src/Serilog.Sinks.Syslog/SyslogLoggerConfigurationExtensions.cs
+++ b/src/Serilog.Sinks.Syslog/SyslogLoggerConfigurationExtensions.cs
@@ -144,6 +144,7 @@ namespace Serilog
         /// <param name="facility"><inheritdoc cref="Facility" path="/summary"/> Defaults to <see cref="Facility.Local0"/>.</param>
         /// <param name="useTls">Set to <c>true</c> so that the TCP connection uses SSL/TLS encryption. Otherwise,
         /// the data will be sent unencrypted.</param>
+        /// <param name="allowIPv6">Set to <c>false</c> to disable IPv6</param>
         /// <param name="certProvider">Optionally used to present the syslog server with a client certificate</param>
         /// <param name="certValidationCallback">
         /// Optional callback used to validate the syslog server's certificate. If null, the system default
@@ -158,16 +159,16 @@ namespace Serilog
         /// <param name="formatter">The message formatter</param>
         /// <seealso cref="!:https://github.com/serilog/serilog/wiki/Formatting-Output"/>
         public static LoggerConfiguration TcpSyslog(this LoggerSinkConfiguration loggerSinkConfig,
-            string host, int port = 1468, string appName = null, FramingType framingType = FramingType.OCTET_COUNTING,
-            SyslogFormat format = SyslogFormat.RFC5424, Facility facility = Facility.Local0,
-            bool useTls = false, ICertificateProvider certProvider = null,
-            RemoteCertificateValidationCallback certValidationCallback = null,
-            string outputTemplate = null,
-            LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
-            string messageIdPropertyName = Rfc5424Formatter.DefaultMessageIdPropertyName,
-            PeriodicBatchingSinkOptions batchConfig = null,
-            string sourceHost = null,
-            Func<LogEventLevel, Severity> severityMapping = null, ITextFormatter formatter = null)
+                                                    string host, int port = 1468, string appName = null, FramingType framingType = FramingType.OCTET_COUNTING,
+                                                    SyslogFormat format = SyslogFormat.RFC5424, Facility facility = Facility.Local0,
+                                                    bool useTls = false, bool allowIPv6 = true, ICertificateProvider certProvider = null,
+                                                    RemoteCertificateValidationCallback certValidationCallback = null,
+                                                    string outputTemplate = null,
+                                                    LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
+                                                    string messageIdPropertyName = Rfc5424Formatter.DefaultMessageIdPropertyName,
+                                                    PeriodicBatchingSinkOptions batchConfig = null,
+                                                    string sourceHost = null,
+                                                    Func<LogEventLevel, Severity> severityMapping = null, ITextFormatter formatter = null)
         {
             var messageFormatter = GetFormatter(format, appName, facility, outputTemplate, messageIdPropertyName,
                 sourceHost, severityMapping, formatter);
@@ -179,6 +180,7 @@ namespace Serilog
                 Formatter = messageFormatter,
                 Framer = new MessageFramer(framingType),
                 UseTls = useTls,
+                AllowIPv6 = allowIPv6,
                 CertProvider = certProvider,
                 CertValidationCallback = certValidationCallback
             };


### PR DESCRIPTION
I'm back! 8) 

So from what I can tell, Lambda will return true to Socket.OSSupportsIPv6 but still deny access to it causing a "protocol not supported" exception. Rather than pursuing another method of discovering support this change allows the user to explicitly disable IPv6 in their configuration if necessary. It will default to 'AllowIPv6' which will retain the Socket.OSSupportsIPv6 test.

