### PR TITLE
Remove forced netstandard dependency

### DIFF
--- a/src/Serilog.Sinks.Syslog/Serilog.Sinks.Syslog.csproj
+++ b/src/Serilog.Sinks.Syslog/Serilog.Sinks.Syslog.csproj
@@ -42,7 +42,10 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
     <PackageReference Include="Serilog" Version="2.5.0" />
-    <PackageReference Include="Serilog.Sinks.PeriodicBatching" Version="2.3.0" />
+    <PackageReference Include="Serilog.Sinks.PeriodicBatching" Version="2.3.1" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net462' ">
     <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
   </ItemGroup>
 


### PR DESCRIPTION
## Change
This PR removes the unconditional dependency on `System.Runtime.InteropServices.RuntimeInformation`. It also updates `Serilog.Sinks.PeriodicBatching` a tiny bit, which removes the need for consumers to do that to avoid this issue, but that's not as important as can be done downstream :).

## Why

When building a project targeting net8.0 a large number of unneeded/unused dependencies are added to the `deps.json` manifest.

For the `Serilog.Sinks.Syslog.Sample` project (updated to Serilog 2.10.0, Serilog.Sinks.Console 4.0.0, and targeting `net8.0`) I would expect only a small handful of dependencies, and after my proposed changes that's the case; 6 dependencies. 

Currently, a general build results in 22 extra dependencies, and a linux-x64 build results in 51 extra dependenciens.

![Pasted image 20241004103347](https://github.com/user-attachments/assets/a2dccf82-2a22-4939-ae75-855e4b5f1b73)

My understanding is that these dependencies are technically completely harmless. However, they create a lot of noise in dependency analysis tools and are tricky to explain in documentation. They also currently create a false-positive security alert based off `System.Private.Uri/4.3.0`.

I'm happy to create an issue with more details and explanations

## Testing

Tests seem to run fine with this change, but I haven't done extensive checking of different target frameworks in consuming projects.