### PR TITLE
Add Support for custom SD-ID in RFC5424 Messages

### DIFF
--- a/src/Serilog.Sinks.Syslog/SyslogLoggerConfigurationExtensions.cs
+++ b/src/Serilog.Sinks.Syslog/SyslogLoggerConfigurationExtensions.cs
@@ -54,7 +54,7 @@ namespace Serilog
         /// <param name="formatter">The message formatter</param>
         /// <param name="levelSwitch">A switch allowing the pass-through minimum level
         /// to be changed at runtime.</param>
-        /// <param name="structuredDataId">The structured data ID (SD-ID). Defaults to "meta".</param>
+        /// <param name="structuredDataId">The structured data ID (SD-ID). Only applicable when <paramref name="format"/> is <see cref="SyslogFormat.RFC5424"/>. Defaults to "meta".</param>
         /// <seealso cref="!:https://github.com/serilog/serilog/wiki/Formatting-Output"/>
         public static LoggerConfiguration LocalSyslog(this LoggerSinkConfiguration loggerSinkConfig,
             string appName = null, Facility facility = Facility.Local0, string outputTemplate = null,
@@ -97,7 +97,7 @@ namespace Serilog
         /// <param name="formatter">The message formatter</param>
         /// <param name="levelSwitch">A switch allowing the pass-through minimum level
         /// to be changed at runtime.</param>
-        /// <param name="structuredDataId">The structured data ID (SD-ID). Defaults to "meta".</param>
+        /// <param name="structuredDataId">The structured data ID (SD-ID). Only applicable when <paramref name="format"/> is <see cref="SyslogFormat.RFC5424"/>. Defaults to "meta".</param>
         /// <see cref="!:https://github.com/serilog/serilog/wiki/Formatting-Output"/>
         public static LoggerConfiguration UdpSyslog(this LoggerSinkConfiguration loggerSinkConfig,
             string host, int port = 514, string appName = null, SyslogFormat format = SyslogFormat.RFC3164,
@@ -175,7 +175,7 @@ namespace Serilog
         /// <param name="formatter">The message formatter</param>
         /// <param name="levelSwitch">A switch allowing the pass-through minimum level
         /// to be changed at runtime.</param>
-        /// <param name="structuredDataId">The structured data ID (SD-ID). Defaults to "meta".</param>
+        /// <param name="structuredDataId">The structured data ID (SD-ID). Only applicable when <paramref name="format"/> is <see cref="SyslogFormat.RFC5424"/>. Defaults to "meta".</param>
         /// <seealso cref="!:https://github.com/serilog/serilog/wiki/Formatting-Output"/>
         public static LoggerConfiguration TcpSyslog(this LoggerSinkConfiguration loggerSinkConfig,
             string host, int port = 1468, string appName = null, FramingType framingType = FramingType.OCTET_COUNTING,

--- a/src/Serilog.Sinks.Syslog/SyslogLoggerConfigurationExtensions.cs
+++ b/src/Serilog.Sinks.Syslog/SyslogLoggerConfigurationExtensions.cs
@@ -54,12 +54,13 @@ namespace Serilog
         /// <param name="formatter">The message formatter</param>
         /// <param name="levelSwitch">A switch allowing the pass-through minimum level
         /// to be changed at runtime.</param>
+        /// <param name="structuredDataId">The structured data ID (SD-ID). Defaults to "meta".</param>
         /// <seealso cref="!:https://github.com/serilog/serilog/wiki/Formatting-Output"/>
         public static LoggerConfiguration LocalSyslog(this LoggerSinkConfiguration loggerSinkConfig,
             string appName = null, Facility facility = Facility.Local0, string outputTemplate = null,
             LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
             Func<LogEventLevel, Severity> severityMapping = null,ITextFormatter formatter = null,
-            LoggingLevelSwitch levelSwitch = null)
+            LoggingLevelSwitch levelSwitch = null, string structuredDataId = null)
         {
             if (!LocalSyslogService.IsAvailable)
             {
@@ -68,7 +69,7 @@ namespace Serilog
             }
 
             var messageFormatter = GetFormatter(SyslogFormat.Local, appName, facility, outputTemplate,
-                severityMapping: severityMapping, formatter: formatter);
+                severityMapping: severityMapping, formatter: formatter, structuredDataId: structuredDataId);
             var syslogService = new LocalSyslogService(facility, appName);
             syslogService.Open();
 
@@ -96,6 +97,7 @@ namespace Serilog
         /// <param name="formatter">The message formatter</param>
         /// <param name="levelSwitch">A switch allowing the pass-through minimum level
         /// to be changed at runtime.</param>
+        /// <param name="structuredDataId">The structured data ID (SD-ID). Defaults to "meta".</param>
         /// <see cref="!:https://github.com/serilog/serilog/wiki/Formatting-Output"/>
         public static LoggerConfiguration UdpSyslog(this LoggerSinkConfiguration loggerSinkConfig,
             string host, int port = 514, string appName = null, SyslogFormat format = SyslogFormat.RFC3164,
@@ -104,13 +106,14 @@ namespace Serilog
             string messageIdPropertyName = Rfc5424Formatter.DefaultMessageIdPropertyName,
             string sourceHost = null,
             Func<LogEventLevel, Severity> severityMapping = null, ITextFormatter formatter = null,
-            LoggingLevelSwitch levelSwitch = null)
+            LoggingLevelSwitch levelSwitch = null,
+            string structuredDataId = null)
         {
             if (String.IsNullOrWhiteSpace(host))
                 throw new ArgumentException(nameof(host));
 
             batchConfig ??= DefaultBatchOptions;
-            var messageFormatter = GetFormatter(format, appName, facility, outputTemplate, messageIdPropertyName, sourceHost, severityMapping, formatter);
+            var messageFormatter = GetFormatter(format, appName, facility, outputTemplate, messageIdPropertyName, sourceHost, severityMapping, formatter, structuredDataId);
             var endpoint = ResolveIP(host, port);
 
             var syslogUdpSink = new SyslogUdpSink(endpoint, messageFormatter);
@@ -172,6 +175,7 @@ namespace Serilog
         /// <param name="formatter">The message formatter</param>
         /// <param name="levelSwitch">A switch allowing the pass-through minimum level
         /// to be changed at runtime.</param>
+        /// <param name="structuredDataId">The structured data ID (SD-ID). Defaults to "meta".</param>
         /// <seealso cref="!:https://github.com/serilog/serilog/wiki/Formatting-Output"/>
         public static LoggerConfiguration TcpSyslog(this LoggerSinkConfiguration loggerSinkConfig,
             string host, int port = 1468, string appName = null, FramingType framingType = FramingType.OCTET_COUNTING,
@@ -184,10 +188,11 @@ namespace Serilog
             PeriodicBatchingSinkOptions batchConfig = null,
             string sourceHost = null,
             Func<LogEventLevel, Severity> severityMapping = null, ITextFormatter formatter = null,
-            LoggingLevelSwitch levelSwitch = null)
+            LoggingLevelSwitch levelSwitch = null,
+            string structuredDataId = null)
         {
             var messageFormatter = GetFormatter(format, appName, facility, outputTemplate, messageIdPropertyName,
-                sourceHost, severityMapping, formatter);
+                sourceHost, severityMapping, formatter, structuredDataId);
 
             var config = new SyslogTcpConfig
             {
@@ -228,7 +233,9 @@ namespace Serilog
             string outputTemplate,
             string messageIdPropertyName = null,
             string sourceHost = null,
-            Func<LogEventLevel, Severity> severityMapping = null, ITextFormatter formatter = null)
+            Func<LogEventLevel, Severity> severityMapping = null,
+            ITextFormatter formatter = null,
+            string structuredDataId = null)
         {
             ITextFormatter templateFormatter;
 
@@ -246,7 +253,7 @@ namespace Serilog
             return format switch
             {
                 SyslogFormat.RFC3164 => new Rfc3164Formatter(facility, appName, templateFormatter, sourceHost, severityMapping),
-                SyslogFormat.RFC5424 => new Rfc5424Formatter(facility, appName, templateFormatter, messageIdPropertyName, sourceHost, severityMapping),
+                SyslogFormat.RFC5424 => new Rfc5424Formatter(facility, appName, templateFormatter, messageIdPropertyName, sourceHost, severityMapping, structuredDataId),
                 SyslogFormat.Local => new LocalFormatter(facility, templateFormatter, severityMapping),
                 _ => throw new ArgumentException($"Invalid format: {format}")
             };

--- a/test/Serilog.Sinks.Syslog.Tests/Formatters/SyslogRfc5424FormatterTests.cs
+++ b/test/Serilog.Sinks.Syslog.Tests/Formatters/SyslogRfc5424FormatterTests.cs
@@ -198,7 +198,8 @@ namespace Serilog.Sinks.Syslog.Tests
         [Fact]
         public void Should_format_message_with_custom_sdid()
         {
-            var customFormatter = new Rfc5424Formatter(Facility.User, APP_NAME);
+            const string sdId = "ourSDID@32473";
+            var customFormatter = new Rfc5424Formatter(Facility.User, APP_NAME, structuredDataId: sdId);
 
             var properties = new List<LogEventProperty>
             {
@@ -214,7 +215,7 @@ namespace Serilog.Sinks.Syslog.Tests
             var match = this.regex.Match(formatted);
             match.Success.ShouldBeTrue();
 
-            match.Groups["sdid"].Value.ShouldBe("ourSDID@32473");
+            match.Groups["sdid"].Value.ShouldBe(sdId);
         }
     }
 }

--- a/test/Serilog.Sinks.Syslog.Tests/Serilog.Sinks.Syslog.Tests.csproj
+++ b/test/Serilog.Sinks.Syslog.Tests/Serilog.Sinks.Syslog.Tests.csproj
@@ -4,7 +4,7 @@
     between frameworks. For example, when handling a socket connection timeout, the exception handling logic
     needed to be different for .NET 6.0. So it would be good to include as many frameworks here as we are
     willing to support. -->
-    <TargetFrameworks>net462;netcoreapp3.1;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net462;net6.0;net8.0</TargetFrameworks>
 
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
     <AssemblyName>Serilog.Sinks.Syslog.Tests</AssemblyName>

--- a/test/Serilog.Sinks.Syslog.Tests/Serilog.Sinks.Syslog.Tests.csproj
+++ b/test/Serilog.Sinks.Syslog.Tests/Serilog.Sinks.Syslog.Tests.csproj
@@ -4,7 +4,7 @@
     between frameworks. For example, when handling a socket connection timeout, the exception handling logic
     needed to be different for .NET 6.0. So it would be good to include as many frameworks here as we are
     willing to support. -->
-    <TargetFrameworks>net462;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net462;netcoreapp3.1;net6.0;net8.0</TargetFrameworks>
 
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
     <AssemblyName>Serilog.Sinks.Syslog.Tests</AssemblyName>


### PR DESCRIPTION
Introduces the ability to specify custom Structured Data Identifiers (SD-IDs) in RFC5424-compliant syslog messages. Previously, the SD-ID field was statically defined to `meta`.

The custom value can be defined with the new `structuredDataId` parameter.
```csharp
var log = new LoggerConfiguration()
    .WriteTo.TcpSyslog("10.10.10.14", structuredDataId: "ourSDID@32473")
    .CreateLogger();
```

I have added the unit test `SyslogRfc5424FormatterTests.Should_format_message_with_custom_sdid`.