### PR TITLE
Multi-line Exception Example and Unit Test Assembly Binding Workaround

### DIFF
--- a/test/Serilog.Sinks.Syslog.Tests/Support/Fixture.cs
+++ b/test/Serilog.Sinks.Syslog.Tests/Support/Fixture.cs
@@ -74,5 +74,24 @@ namespace Serilog.Sinks.Syslog.Tests
         // that option is not available on all .NET Framework versions being targeted.
         private static X509Certificate2 LoadCertFromFile(string filename)
             => new X509Certificate2(filename, String.Empty);
+
+        /// <summary>Workaround for unit test failure. See https://stackoverflow.com/a/73914330/8169136.
+        /// As mentioned in other posts on that page, this may not be a problem on every machine. Tried
+        /// a few of the other suggestions on the page as well, but this is the only one that worked.</summary>
+        /// <param name="sender"></param>
+        /// <param name="args"></param>
+        /// <returns>The already loaded version of System.Runtime.CompilerServices.Unsafe, regardless of
+        /// the actual version.</returns>
+        public static Assembly CurrentDomain_AssemblyResolve(object sender, ResolveEventArgs args)
+        {
+            var name = new AssemblyName(args.Name);
+
+            if (name.Name == "System.Runtime.CompilerServices.Unsafe")
+            {
+                return typeof(System.Runtime.CompilerServices.Unsafe).Assembly;
+            }
+
+            return null;
+        }
     }
 }

--- a/test/Serilog.Sinks.Syslog.Tests/TcpSyslogSinkTests.cs
+++ b/test/Serilog.Sinks.Syslog.Tests/TcpSyslogSinkTests.cs
@@ -14,6 +14,9 @@ using Xunit;
 using Shouldly;
 using static Serilog.Sinks.Syslog.Tests.Fixture;
 using Xunit.Abstractions;
+using Serilog.Debugging;
+using Serilog.Events;
+using Serilog.Parsing;
 
 namespace Serilog.Sinks.Syslog.Tests
 {
@@ -229,6 +232,72 @@ namespace Serilog.Sinks.Syslog.Tests
 
             log.Dispose();
             this.cts.Cancel();
+        }
+
+        [Fact]
+        public async Task Multiline_exception()
+        {
+            // Start a simple TCP syslog server that will capture all received messaged
+            var receiver = new TcpSyslogReceiver(null, this.cts.Token);
+            receiver.MessageReceived += (_, msg) =>
+            {
+                SelfLog.WriteLine(msg);
+                this.messagesReceived.Add(msg);
+                this.countdown.Signal();
+            };
+
+            var logger = new LoggerConfiguration();
+
+            logger.WriteTo.TcpSyslog(IPAddress.Loopback.ToString(),
+                receiver.IPEndPoint.Port,
+                framingType: FramingType.OCTET_COUNTING,
+                format: SyslogFormat.RFC5424,
+                facility: Facility.Local0,
+                outputTemplate: "[{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj}{NewLine}{Exception}")
+                .MinimumLevel.Verbose();
+
+            var log = logger.CreateLogger();
+
+            // We will only be sending/testing a single event, but the countdown is expecting 3. Signal it
+            // twice now so we don't have to wait for the timeout.
+            this.countdown.Signal();
+            this.countdown.Signal();
+
+            try
+            {
+                DivideByZero();
+
+                // We should not get here. A DivideByZeroException should be thrown, handled, and logged below.
+            }
+            catch (Exception ex)
+            {
+                var expectedText = new MessageTemplateParser().Parse("Test exception.");
+
+                var le = new LogEvent(DateTimeOffset.UtcNow, LogEventLevel.Fatal, ex, expectedText, Enumerable.Empty<LogEventProperty>());
+
+                log.Write(le);
+            }
+
+            log.Dispose();
+
+            // Wait until the server has received all the messages we sent, or the timeout expires
+            await this.countdown.WaitAsync(TimeoutInSeconds, this.cts.Token);
+
+            // The server should have received all 3 messages sent by the sink
+            this.messagesReceived.Count.ShouldBe(1);
+            this.messagesReceived.ShouldAllBe(x => x.Split('\r', '\n').Length > 1);
+
+            this.cts.Cancel();
+        }
+
+        private static int DivideByZero()
+        {
+            // Just an additional method to be called, so as to increase the depth of the stack trace of the exception.
+            var i = 0;
+            var j = 42;
+            var k = j / i;
+
+            return k;
         }
     }
 }

--- a/test/Serilog.Sinks.Syslog.Tests/TcpSyslogSinkTests.cs
+++ b/test/Serilog.Sinks.Syslog.Tests/TcpSyslogSinkTests.cs
@@ -50,6 +50,8 @@ namespace Serilog.Sinks.Syslog.Tests
             // disabling the Serilog Selflog at the same time. So for any unit test classes that utilize
             // this, we will have to instruct xUnit to run them serially with the [Collection] attribute.
             Serilog.Debugging.SelfLog.Enable(x => { output.WriteLine(x); System.Diagnostics.Debug.WriteLine(x); });
+
+            AppDomain.CurrentDomain.AssemblyResolve += new ResolveEventHandler(CurrentDomain_AssemblyResolve);
         }
 
         public void Dispose()

--- a/test/Serilog.Sinks.Syslog.Tests/UdpSyslogSinkTests.cs
+++ b/test/Serilog.Sinks.Syslog.Tests/UdpSyslogSinkTests.cs
@@ -14,6 +14,8 @@ using Shouldly;
 using Serilog.Events;
 using Xunit.Abstractions;
 using static Serilog.Sinks.Syslog.Tests.Fixture;
+using Serilog.Parsing;
+using Serilog.Debugging;
 
 namespace Serilog.Sinks.Syslog.Tests
 {
@@ -301,17 +303,66 @@ namespace Serilog.Sinks.Syslog.Tests
             await TestLoggerFromExtensionMethod(logger, receiver, altLogEvents: logEvents, altPriority: 128);
         }
 
+        [Fact]
+        public async Task Extension_method_config_with_Rfc3164_format_and_fatal_log_level_exception()
+        {
+            var receiver = new UdpSyslogReceiver(this.cts.Token);
+
+            var logger = new LoggerConfiguration();
+
+            logger.WriteTo.UdpSyslog(IPAddress.Loopback.ToString(),
+                receiver.ListeningIPEndPoint.Port,
+                format: SyslogFormat.RFC3164,
+                outputTemplate: "[{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj}{NewLine}{Exception}")
+                .MinimumLevel.Verbose();
+
+            // We will only be sending/testing a single event, but the countdown is expecting 3. Signal it
+            // twice now so we don't have to wait for the timeout.
+            this.countdown.Signal();
+            this.countdown.Signal();
+
+            try
+            {
+                DivideByZero();
+
+                // We should not get here. A DivideByZeroException should be thrown, handled, and logged below.
+            }
+            catch (Exception ex)
+            {
+                // The TestLoggerFromExtensionMethod() method performs a check and expects this text to be matched
+                // at the end of the string. Well, since we are doing an exception, the exception will be at the
+                // end of the string, and we cannot possibly match it. So a bit of a hack is to just specify the
+                // empty string, which will make it/allow it to successfully match anything.
+                var expectedText = new MessageTemplateParser().Parse("");
+
+                var le = new LogEvent(DateTimeOffset.UtcNow, LogEventLevel.Fatal, ex, expectedText, Enumerable.Empty<LogEventProperty>());
+
+                await TestLoggerFromExtensionMethod(logger, receiver, 1, new[] { le }, altPriority: 128);
+            }
+        }
+
+        private static int DivideByZero()
+        {
+            // Just an additional method to be called, so as to increase the depth of the stack trace of the exception.
+            var i = 0;
+            var j = 42;
+            var k = j / i;
+
+            return k;
+        }
+
         private async Task TestLoggerFromExtensionMethod(LoggerConfiguration logger, UdpSyslogReceiver receiver, int expected = NumberOfEventsToSend, LogEvent[] altLogEvents = null, string altPropName = null, int? altPriority = null)
         {
             receiver.MessageReceived += (_, msg) =>
             {
                 this.messagesReceived.Add(msg);
+                SelfLog.WriteLine(msg);
                 this.countdown.Signal();
             };
 
             var log = logger.CreateLogger();
 
-            var logEvents = altLogEvents ?? Some.LogEvents(NumberOfEventsToSend);
+            var logEvents = altLogEvents ?? Some.LogEvents(expected);
 
             foreach (var item in logEvents)
             {
@@ -326,7 +377,7 @@ namespace Serilog.Sinks.Syslog.Tests
             if (expected > 0)
             {
                 // The server should have received all 3 messages sent by the sink
-                this.messagesReceived.Count.ShouldBe(NumberOfEventsToSend);
+                this.messagesReceived.Count.ShouldBe(expected);
                 this.messagesReceived.ShouldAllBe(x => logEvents.Any(e => x.EndsWith(e.MessageTemplate.Text)));
             }
 

--- a/test/Serilog.Sinks.Syslog.Tests/UdpSyslogSinkTests.cs
+++ b/test/Serilog.Sinks.Syslog.Tests/UdpSyslogSinkTests.cs
@@ -39,6 +39,8 @@ namespace Serilog.Sinks.Syslog.Tests
             // disabling the Serilog Selflog at the same time. So for any unit test classes that utilize
             // this, we will have to instruct xUnit to run them serially with the [Collection] attribute.
             Serilog.Debugging.SelfLog.Enable(x => { output.WriteLine(x); System.Diagnostics.Debug.WriteLine(x); });
+
+            AppDomain.CurrentDomain.AssemblyResolve += new ResolveEventHandler(CurrentDomain_AssemblyResolve);
         }
 
         public void Dispose()


### PR DESCRIPTION
See 
https://github.com/IonxSolutions/serilog-sinks-syslog/issues/70

and

https://github.com/IonxSolutions/serilog-sinks-syslog/issues/82

After this, all unit tests pass on my machine:
![image](https://github.com/user-attachments/assets/500da8a1-2846-43fb-9131-53bfd9a3a396)
