### PR TITLE
Remove Context from output message in RFC3164 

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ var log = new LoggerConfiguration()
 An example of an RFC3164 message:
 
 ```
-<12>Dec 19 04:01:02 MYHOST MyApp[1912]: [Source.Context] This is a test message
+<12>Dec 19 04:01:02 MYHOST MyApp[1912]: This is a test message
 ```
 
 An example of an RFC5424 message:

--- a/src/Serilog.Sinks.Syslog/Sinks/Formatters/Rfc3164Formatter.cs
+++ b/src/Serilog.Sinks.Syslog/Sinks/Formatters/Rfc3164Formatter.cs
@@ -56,37 +56,9 @@ namespace Serilog.Sinks.Syslog
 
             var timestamp = String.Format(CultureInfo.InvariantCulture, dateFormat, logEvent.Timestamp);
 
-            // If the log event contains a source context, we will render it as part of the syslog CONTENT
-            // field, as RFC3164 doesn't have anywhere else to put it
-            var context = GetSourceContext(logEvent);
-
             var msg = RenderMessage(logEvent);
 
-            return context != null
-                ? $"<{priority}>{timestamp} {this.Host} {this.applicationName}[{ProcessId}]: [{context}] {msg}"
-                : $"<{priority}>{timestamp} {this.Host} {this.applicationName}[{ProcessId}]: {msg}";
-        }
-
-        /// <summary>
-        /// Get the LogEvent's SourceContext in a format suitable for use as part of the CONTENT field
-        /// of a syslog message (All Serilog property values are quoted and escaped, which is unnecessary
-        /// here)
-        /// </summary>
-        /// <param name="logEvent">The LogEvent to extract the context from</param>
-        /// <returns>The processed SourceContext</returns>
-        private static string GetSourceContext(LogEvent logEvent)
-        {
-            var hasContext = logEvent.Properties.TryGetValue("SourceContext", out LogEventPropertyValue propertyValue);
-
-            if (!hasContext)
-                return null;
-
-            // Trim surrounding quotes, and unescape all others
-            var result = propertyValue
-                .ToString()
-                .TrimAndUnescapeQuotes();
-
-            return result;
+            return $"<{priority}>{timestamp} {this.Host} {this.applicationName}[{ProcessId}]: {msg}";
         }
     }
 }

--- a/test/Serilog.Sinks.Syslog.Tests/Formatters/SyslogRfc3164FormatterTests.cs
+++ b/test/Serilog.Sinks.Syslog.Tests/Formatters/SyslogRfc3164FormatterTests.cs
@@ -67,36 +67,6 @@ namespace Serilog.Sinks.Syslog.Tests
         }
 
         [Fact]
-        public void Should_format_message_with_source_context()
-        {
-            var properties = new List<LogEventProperty> {
-                new LogEventProperty("SourceContext", new ScalarValue(@"Test.Cont""ext"))
-            };
-
-            var template = new MessageTemplateParser().Parse("This is a test message");
-            var warnEvent = new LogEvent(this.timestamp, LogEventLevel.Warning, null, template, properties);
-
-            var formatted = this.formatter.FormatMessage(warnEvent);
-            this.output.WriteLine($"RFC3164 with source context: {formatted}");
-
-            var match = this.regex.Match(formatted);
-            match.Success.ShouldBeTrue();
-
-            match.Groups["pri"].Value.ShouldBe("<12>");
-            match.Groups["timestamp"].Value.ShouldBe("Dec 19 04:01:02");
-            match.Groups["host"].Value.ShouldBe(Host);
-            match.Groups["proc"].Value.ToInt().ShouldBeGreaterThan(0);
-
-            // Spaces and anything other than printable ASCII should have been removed, and should have
-            // been truncated to 32 chars
-            match.Groups["app"].Value.ShouldBe("TestAppWithAVeryLongNameThatShou");
-
-            // Ensure that we busted the source context out of its enclosing quotes, and that we unescaped
-            // any other quotes
-            match.Groups["msg"].Value.ShouldBe("[Test.Cont\"ext] This is a test message");
-        }
-
-        [Fact]
         public void Should_override_log_host_name()
         {
             var template = new MessageTemplateParser().Parse("This is a test message");


### PR DESCRIPTION
Following from #85 

In order to allow the user explicitly set the source context output when using the RFC3164 format, the following changes were introduced:

- removed the checks for the source context rendering on the formatter and
- Removed the redundant test checking for source context rendering on the message. 